### PR TITLE
Option to Disable Automatic Webbrowser Opening

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -33,6 +33,13 @@ def test_oauth2():
     assert response.status_code == 200
 
 
+def test_oauth2_without_browser():
+    oauth = OAuth2(None, None, from_file='oauth2.yaml', browser_callback=False)
+    response = oauth.session.get('https://social.yahooapis.com/v1/me/guid?format=json')
+    logging.debug(pretty_json(response.content))
+    assert response.status_code == 200
+
+
 @pytest.fixture
 def data():
     return {

--- a/yahoo_oauth/oauth.py
+++ b/yahoo_oauth/oauth.py
@@ -54,6 +54,11 @@ class BaseOAuth(object):
         self.oauth_version = oauth_version
         self.callback_uri = vars(self).get('callback_uri', CALLBACK_URI)
 
+        if 'browser_callback' in kwargs.keys():
+            self.browser_callback = kwargs.get('browser_callback')
+        else:
+            self.browser_callback = True
+
         # Init OAuth
         if self.oauth_version == 'oauth1':
             service_params = {
@@ -107,10 +112,13 @@ class BaseOAuth(object):
         else:
             authorize_url = self.oauth.get_authorize_url(redirect_uri=self.callback_uri, response_type='code')
 
-        logger.debug("AUTHORISATION URL : {0}".format(authorize_url))
-        # Open authorize_url
-        webbrowser.open(authorize_url)
-        self.verifier = input("Enter verifier : ")
+        logger.debug("AUTHORIZATION URL : {0}".format(authorize_url))
+        if self.browser_callback:
+            # Open authorize_url
+            webbrowser.open(authorize_url)
+            self.verifier = input("Enter verifier : ")
+        else:
+            self.verifier = input("AUTHORIZATION URL : {0}\nEnter verifier : ".format(authorize_url))
 
         self.token_time = time.time()
 


### PR DESCRIPTION
Currently the OAuth process in the `yahoo-oauth` library _always_ opens a web browser when a new token is requested. However, if running OAuth inside a container (Docker), it is extremely difficult (if not impossible in some environments) for the Docker container to talk to the host machine.

As such, this small PR adds the ability to include a keyword/named argument, `browser_callback`, which, when set to `False`, will simply include the authorization URL in the verification code input request, allowing users to click on the link themselves to get the Yahoo OAuth verification code. 