### PR TITLE
Adding flag for storing secrets in file

### DIFF
--- a/yahoo_oauth/oauth.py
+++ b/yahoo_oauth/oauth.py
@@ -17,7 +17,7 @@ import base64
 
 from rauth.utils import parse_utf8_qsl
 
-from yahoo_oauth.utils import services, CALLBACK_URI
+from yahoo_oauth.utils import services, CALLBACK_URI, STORE_FILE_FLAG
 from yahoo_oauth.utils import get_data, write_data
 from yahoo_oauth.logger import YahooLogger
 
@@ -53,6 +53,7 @@ class BaseOAuth(object):
 
         self.oauth_version = oauth_version
         self.callback_uri = vars(self).get('callback_uri', CALLBACK_URI)
+        self.store_file = vars(self).get('store_file', STORE_FILE_FLAG)
 
         if 'browser_callback' in kwargs.keys():
             self.browser_callback = kwargs.get('browser_callback')
@@ -97,7 +98,8 @@ class BaseOAuth(object):
         else:
             self.session = self.oauth.get_session(token=self.access_token)
 
-        write_data(data, vars(self).get('from_file', 'secrets.json'))
+        if self.store_file:
+            write_data(data, vars(self).get('from_file', 'secrets.json'))
 
     def handler(self,):
         """* get request token if OAuth1

--- a/yahoo_oauth/utils.py
+++ b/yahoo_oauth/utils.py
@@ -23,6 +23,8 @@ services = {
 
 CALLBACK_URI = 'oob'
 
+STORE_FILE_FLAG = True
+
 def get_file_extension(filename):
     return os.path.splitext(filename)
 


### PR DESCRIPTION
Implements optional file storage for secrets as described in https://github.com/josuebrunel/yahoo-oauth/issues/58

Created a new flag in utlis.py called STORE_FILE_FLAG that defaults to True. This flag will be checked before calling the write_data function and only call it if the flag is set to True.

The flag can be set via a keyword argument while creating an Oauth Object.

`OAuth2(self.KEY, self.SECRET, store_file=False)`